### PR TITLE
Update Dockerfile for stable Python and correct entrypoint

### DIFF
--- a/Anti-Trade-Spam-Permalocked/Config-and-Setup/docker-related/dockerfile
+++ b/Anti-Trade-Spam-Permalocked/Config-and-Setup/docker-related/dockerfile
@@ -6,7 +6,7 @@
 
 # Want to help us make this template better? Share your feedback here: https://forms.gle/ybq9Krt8jtBL3iCk7
 
-ARG PYTHON_VERSION=3.13.3
+ARG PYTHON_VERSION=3.11
 FROM python:${PYTHON_VERSION}-slim as base
 
 # Prevents Python from writing pyc files.
@@ -48,4 +48,4 @@ COPY . .
 EXPOSE 8000
 
 # Run the application.
-CMD tradeS2D2.py
+CMD python tradeSpamSpammersDnD.py


### PR DESCRIPTION
## Summary
- use Python 3.11 image
- run tradeSpamSpammersDnD via Python in docker

## Testing
- `python -m py_compile tradeSpamSpammersDnD.py Anti-Trade-Spam-Permalocked/Config-and-Setup/spinUpVm.py packetForge.py`

------
https://chatgpt.com/codex/tasks/task_e_684145315bb48324bd18968ca6fff802